### PR TITLE
Deserialize.data by ref: it's owned by the caller

### DIFF
--- a/src/Context.h
+++ b/src/Context.h
@@ -16,9 +16,9 @@ namespace ots{
 class Deserialize
 {
 private:
+	std::vector<unsigned char> &data; // data life is owned by the caller
 public:
-	std::vector<unsigned char> data;
-	Deserialize(std::vector<unsigned char> data) : data(data) {}
+	Deserialize(std::vector<unsigned char> &data) : data(data) {}
 	~Deserialize() {}
 
 	unsigned char read8(){


### PR DESCRIPTION
avoiding unnecessary copy